### PR TITLE
feat: add 'Open in Terminal' button for standalone distrobox sessions…

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -265,6 +265,7 @@ version = "1.1.0"
 dependencies = [
  "chrono",
  "jwalk",
+ "libc",
  "log",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,4 +30,5 @@ urlencoding = "2"
 jwalk = "0.8"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "process"] }
 chrono = "0.4"
+libc = "0.2"
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod space;
 pub mod storage;
 pub mod system;
 pub mod vscode;
+pub mod terminal;

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -1,0 +1,118 @@
+use crate::commands::logs;
+use crate::core::util::build_host_command;
+use std::fs::OpenOptions;
+use std::io;
+use std::process::Stdio;
+
+use std::os::unix::process::CommandExt;
+
+fn shell_escape_single(s: &str) -> String {
+    // Escape single quotes for sh/bash: ' -> '\'' (implemented as: '"'"')
+    format!("'{}'", s.replace('\'', "'\"'\"'"))
+}
+
+/// Open a distrobox environment in a native host terminal emulator.
+///
+/// Attempts ptyxis, then xdg-terminal-exec, then gnome-terminal and konsole.
+/// The spawned terminal is detached from the Tauri process using setsid and
+/// stdio redirected to /dev/null so it survives when the parent exits.
+#[tauri::command]
+pub fn open_in_terminal(app: tauri::AppHandle, env_name: String) -> Result<String, String> {
+    logs::info(&app, "terminal", format!("open_in_terminal start: '{}'", env_name));
+    if env_name.trim().is_empty() {
+        return Err("Environment name is empty.".to_string());
+    }
+
+    let candidates = ["ptyxis", "xdg-terminal-exec", "gnome-terminal", "konsole"];
+    let mut last_err: Option<String> = None;
+
+    for bin in &candidates {
+        // quick existence check
+        let is_present = build_host_command("sh")
+            .args(["-lc", &format!("command -v {} >/dev/null 2>&1", bin)])
+            .status()
+            .ok()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !is_present {
+            continue;
+        }
+
+        let escaped = shell_escape_single(&env_name);
+
+        let mut cmd = build_host_command(bin);
+        match *bin {
+            "ptyxis" => {
+                cmd.arg("--");
+                cmd.arg("distrobox");
+                cmd.arg("enter");
+                cmd.arg(&env_name);
+            }
+            "xdg-terminal-exec" => {
+                // xdg-terminal-exec typically forwards args as the command to run
+                cmd.arg("distrobox");
+                cmd.arg("enter");
+                cmd.arg(&env_name);
+            }
+            "gnome-terminal" => {
+                // run via bash -lc to ensure a login-like execution
+                cmd.arg("--");
+                cmd.arg("bash");
+                cmd.arg("-lc");
+                cmd.arg(&format!("distrobox enter {}", escaped));
+            }
+            "konsole" => {
+                // konsole uses -e to execute a command
+                cmd.arg("-e");
+                cmd.arg("bash");
+                cmd.arg("-lc");
+                cmd.arg(&format!("distrobox enter {}", escaped));
+            }
+            _ => {}
+        }
+
+        // Redirect stdio to /dev/null so the child doesn't keep file descriptors
+        // from the parent and can continue after parent exits.
+        let devnull = OpenOptions::new().read(true).write(true).open("/dev/null");
+        if let Ok(f) = devnull {
+            let stdin = Stdio::from(f.try_clone().unwrap_or_else(|_| f.try_clone().unwrap()));
+            let stdout = Stdio::from(f.try_clone().unwrap_or_else(|_| f.try_clone().unwrap()));
+            let stderr = Stdio::from(f);
+            cmd.stdin(stdin).stdout(stdout).stderr(stderr);
+        }
+
+        // Detach from controlling terminal and create new session so the child
+        // does not receive SIGHUP when the parent exits.
+        unsafe {
+            cmd.pre_exec(|| {
+                // SAFETY: calling libc::setsid is a well-known POSIX operation to
+                // create a new session. We translate a -1 return into an io::Error
+                // so the spawn() call fails cleanly.
+                let rc = libc::setsid();
+                if rc == -1 {
+                    return Err(io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        match cmd.spawn() {
+            Ok(_child) => {
+                let msg = format!("Terminal launched using '{}'.", bin);
+                logs::info(&app, "terminal", format!("open_in_terminal ok -> {}", bin));
+                return Ok(msg);
+            }
+            Err(e) => {
+                last_err = Some(format!("{}: {}", bin, e));
+                continue;
+            }
+        }
+    }
+
+    let err = format!(
+        "Could not launch terminal. Last error: {:?}",
+        last_err
+    );
+    logs::error(&app, "terminal", err.clone());
+    Err(err)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,8 @@ pub fn run() {
             commands::env::get_environment_manifest,
             // VS Code
             commands::vscode::open_in_vscode,
+            // Terminal
+            commands::terminal::open_in_terminal,
             // Space
             commands::space::get_environment_space,
             commands::space::resolve_project_path,

--- a/src/components/EnvironmentRow.tsx
+++ b/src/components/EnvironmentRow.tsx
@@ -190,6 +190,20 @@ function EnvironmentRowImpl({ env, base, onOpenVSCode, onDelete }: Props) {
     setManageOpen(true);
   }, [resolvedPath, env.name]);
 
+  const handleOpenTerminal = useCallback(async () => {
+    toast.info("Opening terminal…");
+    await invoke("client_log", { source: "ui", level: "INFO", message: `open_in_terminal requested for '${env.name}'` }).catch(() => {});
+    try {
+      const backendMsg = await invoke<string>("open_in_terminal", { envName: env.name });
+      toast.success("Terminal launched");
+      await invoke("client_log", { source: "ui", level: "INFO", message: `open_in_terminal ok for '${env.name}': ${backendMsg}` }).catch(() => {});
+    } catch (e) {
+      const msg = toErrMsg(e);
+      await invoke("client_log", { source: "ui", level: "ERROR", message: `open_in_terminal failed for '${env.name}': ${msg}` }).catch(() => {});
+      toast.error(msg || "Open terminal failed");
+    }
+  }, [env.name]);
+
   return (
     <div ref={containerRef} style={{
       position: "relative",
@@ -320,6 +334,9 @@ function EnvironmentRowImpl({ env, base, onOpenVSCode, onDelete }: Props) {
       <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
         <button onClick={() => onOpenVSCode(env.name)} style={{ flex: 1 }}>
           💻 Open in VS Code (remote)
+        </button>
+        <button onClick={handleOpenTerminal} style={{ flex: 1, background: '#444', color: '#e5e7eb', border: 'none', borderRadius: 6, padding: '8px 10px' }}>
+          🖥️ Open in Terminal
         </button>
       </div>
 


### PR DESCRIPTION
Fixes #10

## Description
Adds an "Open in Terminal" button to the environment cards. This allows users to drop directly into standalone Distrobox sessions using their native host terminal (prioritizing `ptyxis` with fallbacks to other common emulators). 

**Key implementation:**
* The spawned terminal process is safely detached via `libc::setsid`. This ensures the terminal session stays alive even if Bazzite Architect is closed.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Architecture update

## Architecture Checklist:
- [x] My code follows the `ARCHITECTURE.md` guidelines.
- [x] I have routed system commands through the Host-Executor (`build_host_command_async`) where necessary.
- [x] I have performed a self-review of my own code.