### PR TITLE
refactor(backend): fix comment conventions for invariants and safety …

### DIFF
--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -11,7 +11,7 @@ where
     F: FnOnce(&mut VecDeque<String>) -> R,
 {
     let mutex = LOGS.get_or_init(|| Mutex::new(VecDeque::new()));
-    // SAFETY: LOGS is initialized above with a Mutex<Void>. Acquiring the lock
+    // INVARIANT: LOGS is initialized above with a Mutex<Void>. Acquiring the lock
     // only panics if a poisoning scenario occurs (thread panicked while holding
     // the lock). The application tolerates poisoning as a signal of higher-level
     // process failure; recovering with unwrap here is acceptable because logging

--- a/src-tauri/src/commands/space.rs
+++ b/src-tauri/src/commands/space.rs
@@ -90,7 +90,7 @@ fn ensure_cache_file(app: &tauri::AppHandle) -> PathBuf {
 fn load_cache(app: &tauri::AppHandle) {
     let mut cache = SIZE_CACHE
         .get_or_init(|| Mutex::new(SizeCache::default()))
-        // SAFETY: this mutex is initialized above in a single-threaded fashion on
+        // INVARIANT: this mutex is initialized above in a single-threaded fashion on
         // first access. Locking may panic only if the mutex is poisoned due to a
         // thread panic while holding it; in this process-level cache that would
         // indicate a serious internal error and it is acceptable to propagate

--- a/src-tauri/src/core/devcontainer.rs
+++ b/src-tauri/src/core/devcontainer.rs
@@ -51,9 +51,6 @@ pub fn write_devcontainer_files(
         // steps in postStartCommand executes them after the container is
         // started and the VS Code server is attached, preventing the UI from
         // stalling (the command is still allowed to fail harmlessly).
-        // SAFETY: `obj` is constructed above with a JSON object literal via
-        // serde_json::json!({ ... }). That macro produces a Value::Object, so
-        // as_object_mut() will always return Some for this `obj` instance.
         obj.as_object_mut().expect("devcontainer invariant: `obj` was constructed with serde_json::json! as an object literal, so as_object_mut() must return Some").insert(
             "postStartCommand".into(),
             serde_json::Value::String(cmd.to_string()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,7 +92,7 @@ pub fn run() {
             Ok(())
         });
 
-    // SAFETY: run() returns a Result which will only be Err on startup failure
+    // INVARIANT: run() returns a Result which will only be Err on startup failure
     // (invalid configuration or platform support issues). It is appropriate to
     // treat failure to run the application as fatal at this point and surface a
     // clear message for diagnostic purposes.


### PR DESCRIPTION
## Description
This PR aligns our codebase with idiomatic Rust comment conventions regarding panics and unwinds. 
- Renamed `// SAFETY:` comments to `// INVARIANT:` when justifying `.expect()` calls, as the `SAFETY` tag is strictly reserved for actual `unsafe {}` blocks in the Rust ecosystem.
- Removed redundant comments where the invariant is already fully explained within the `.expect("...")` message itself.
- Verified that legitimate `// SAFETY:` comments (e.g., for the `libc::setsid` FFI call in `terminal.rs`) remain intact.

Resolves #9

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Architecture update

## Architecture Checklist:
- [x] My code follows the `ARCHITECTURE.md` guidelines.
- [ ] I have routed system commands through the Host-Executor (`build_host_command_async`) where necessary.
- [x] I have performed a self-review of my own code.